### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ language: python
 python:
   - "3.7"
 # command to install dependencies
-install: "pip install -r requirements.pip"
+install: "pip install ."
 # command to run tests
 script: pytest

--- a/autovar/test/test_identify.py
+++ b/autovar/test/test_identify.py
@@ -56,12 +56,12 @@ def test_rename_nomjd():
     exp_name = "M1_ip_20d0_2019d01d25T15d54d10d861857_1a6_UNKNOWN_kb92.csv"
     assert name == exp_name
 
-def test_extract_photometry(tmpdir):
+def test_extract_photometry(tmp_path):
+    # tmp_path is a Path object for a temporary directory
     infile = TEST_PATHS['parent'] / 'photometry_test.fits'
-    indir = tmpdir.mkdir("autovar")
-    result_file = extract_photometry(infile, indir, "test.csv")
+    result_file = extract_photometry(infile, tmp_path, "test.csv")
     # Test returned file is where we expect it for given filename
-    assert result_file == indir.join("test.csv")
+    assert result_file == tmp_path / "test.csv"
 
     result_phot = numpy.genfromtxt(result_file, dtype=float, delimiter=',')
     test_photfile = TEST_PATHS['parent'] / 'photFile_test.csv'


### PR DESCRIPTION
Re the second commit, `pytest` has different fixtures for temporary files. `tmpdir` returns a `py.path.local` object, whereas `tmp_path` returns a `pathlib.Path` (which is the kind used all throughout the autovar code). I changed the test to use `tmp_path`.

I think `tmp_path` should be preferred now since the `py` library is 'in maintenance mode' according to [its homepage](https://pypi.org/project/py/). This was news to me as I have always used `tmpdir`...